### PR TITLE
Fix removal of slashes that are needed when using mount points

### DIFF
--- a/example/MountPoint.pm
+++ b/example/MountPoint.pm
@@ -1,0 +1,20 @@
+package MountPoint;
+use Mojo::Base 'Mojolicious';
+
+# This method will run once at server start
+sub startup {
+    my $app = shift;
+
+    $app->plugin('Mojolicious::Plugin::ReverseProxy', {
+        destination_url => 'http://remotehost/',
+        mount_point     => '/foo',
+        req_processor   => sub {
+            my $ctrl = shift;
+            my $req  = shift;
+            my $opt  = shift;
+            $ctrl->render(text => $req->url->to_string);
+        },
+    });
+}
+
+1;

--- a/lib/Mojolicious/Plugin/ReverseProxy.pm
+++ b/lib/Mojolicious/Plugin/ReverseProxy.pm
@@ -24,7 +24,7 @@ my $make_req = sub {
     $url->port($dest_url->port);
     if ($mount_point){
         my $req_path = $url->path;
-        $req_path =~ s[^\Q${mount_point}\E/*][];
+        $req_path =~ s[^\Q${mount_point}\E][];
         $url->path($req_path);
     }
     $tx->req->headers->header('Host',$url->host_port);

--- a/t/mount-point.t
+++ b/t/mount-point.t
@@ -1,0 +1,18 @@
+use FindBin;
+use lib $FindBin::Bin.'/../3rd/lib/perl5';
+use lib $FindBin::Bin.'/../lib';
+use lib $FindBin::Bin.'/../example';
+
+use Test::More tests => 5;
+use Test::Mojo;
+
+use_ok 'Mojolicious::Plugin::ReverseProxy';
+use_ok 'MountPoint';
+
+my $t = Test::Mojo->new('MountPoint');
+
+$t = $t->get_ok('/foo/bar/baz')
+       ->status_is(200)
+       ->content_is('http://remotehost/bar/baz');
+
+exit 0;


### PR DESCRIPTION
If one serves data from remotehost/* as localhost/foo/*, then a request like:
  GET https://localhost/foo/bar/baz
should result in:
  GET https://remotehost/bar/baz
but it resulted in:
  GET http://remotehost/foo/bar/bar/baz
because of how Mojo::URL handles setting the ->path using an absolute path
string (starting with slash) versus a relativ path string.