### PR TITLE
Fix removal of destination paths when using mount points

### DIFF
--- a/example/RemotePath.pm
+++ b/example/RemotePath.pm
@@ -1,0 +1,20 @@
+package RemotePath;
+use Mojo::Base 'Mojolicious';
+
+# This method will run once at server start
+sub startup {
+    my $app = shift;
+
+    $app->plugin('Mojolicious::Plugin::ReverseProxy', {
+        destination_url => 'http://remotehost/bar/',
+        mount_point     => '/foo',
+        req_processor   => sub {
+            my $ctrl = shift;
+            my $req  = shift;
+            my $opt  = shift;
+            $ctrl->render(text => $req->url->to_string);
+        },
+    });
+}
+
+1;

--- a/lib/Mojolicious/Plugin/ReverseProxy.pm
+++ b/lib/Mojolicious/Plugin/ReverseProxy.pm
@@ -19,12 +19,14 @@ my $make_req = sub {
     my $mount_point = shift;
     my $tx = Mojo::Transaction::HTTP->new( req=> $c->req->clone );
     my $url = $tx->req->url;
+    my $req_path = $url->path;
     $url->scheme($dest_url->scheme);
     $url->host($dest_url->host);
     $url->port($dest_url->port);
+    $url->path($dest_url->path);
+    $url->path->trailing_slash(1);
     if ($mount_point){
-        my $req_path = $url->path;
-        $req_path =~ s[^\Q${mount_point}\E][];
+        $req_path =~ s[^\Q${mount_point}\E/*][];
         $url->path($req_path);
     }
     $tx->req->headers->header('Host',$url->host_port);

--- a/t/remote-path.t
+++ b/t/remote-path.t
@@ -1,0 +1,18 @@
+use FindBin;
+use lib $FindBin::Bin.'/../3rd/lib/perl5';
+use lib $FindBin::Bin.'/../lib';
+use lib $FindBin::Bin.'/../example';
+
+use Test::More tests => 5;
+use Test::Mojo;
+
+use_ok 'Mojolicious::Plugin::ReverseProxy';
+use_ok 'RemotePath';
+
+my $t = Test::Mojo->new('RemotePath');
+
+$t = $t->get_ok('/foo/baz')
+       ->status_is(200)
+       ->content_is('http://remotehost/bar/baz');
+
+exit 0;


### PR DESCRIPTION
If one serves data from remotehost/bar/* as localhost/foo/*, then a request like:
  GET https://localhost/foo/baz
should result in:
  GET https://remotehost/bar/baz
but it resulted in:
  GET http://remotehost/baz